### PR TITLE
fix(terraform): update allowed tf versions list due to gke module issue

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.13"
 }


### PR DESCRIPTION
to avoid issue in gke module with tf 0.13 which is not supported yet
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/677